### PR TITLE
[SEASK-67] Provision AMI image along with Hyper-V images 

### DIFF
--- a/packer/build-vm.ps1
+++ b/packer/build-vm.ps1
@@ -56,20 +56,20 @@ Invoke-CreateFolders
 # Download base image from S3 only for Starter Kit build
 $fileName = Split-Path $PackerFile -leaf
 if ($DownloadBaseImage -and ($fileName -eq "sea-starter-kit-win2019-eval.pkr.hcl")) {
-    
+
     if (Test-Path "downloads/BaseQuickStartVM-Current.zip") {
         Write-Output "Deleting old file"
         Remove-Item -Path "downloads/BaseQuickStartVM-Current.zip" -Force
     }
 
     Write-Output "Downloading base image from S3"
-    $url = "https://edfidata.s3-us-west-2.amazonaws.com/Starter+Kits/VM/BaseQuickStartVM/BaseQuickStartVM-Current.zip"
+    $url = "https://edfi-starter-kits.s3-us-east-2.amazonaws.com/BaseQuickStartVM/BaseQuickStartVM-Current.zip"
     $downloadedFile = Get-FileFromInternet $url
-	
+
     if (-not (Get-InstalledModule | Where-Object -Property Name -eq "7Zip4Powershell")) {
         Install-Module -Force -Scope CurrentUser -Name 7Zip4Powershell
     }
-	
+
     Expand-7Zip -ArchiveFileName $downloadedFile -TargetPath $buildPath
 }
 


### PR DESCRIPTION
1.Existing TeamCity build SEAModernizationStarterKit.QuickStartVM
 updated to use new s3 bucket location
2. Upload the artifact to S3 only for ed-fi-starter-kit.vhdx file and disabled zip step.

Please verify https://intedfitools1.msdf.org/buildConfiguration/EdFi_SharedResources_StarterKit_SEAModernizationStarterKitQuickStartVM/132425


New build SEAModernizationStarterKit.QuickStartAMI created for AMI image https://intedfitools1.msdf.org/buildConfiguration/EdFi_SharedResources_StarterKit_SEAModernizationStarterKitQuickStartAMI/132447