### PR TITLE
[SEASK-81] Forcing nuget to use 5.3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,14 @@ jobs:
       - name: Test Starter Kit Sample Extension
         run: dotnet test $env:GITHUB_WORKSPACE/Starter-Kit-SEA-Data-Collection/sample-extension/EdFi.Ods.Extensions.Sk/ --no-restore --verbosity normal
 
+      - name: Version
+        run: nuget help
+
+      - name: Setup Nuget Version
+        uses: nuget/setup-nuget@v1
+        with:
+          nuget-version: '5.3.1'
+
       - name: Pack
         run: nuget pack $env:GITHUB_WORKSPACE/Starter-Kit-SEA-Data-Collection/sample-extension/EdFi.Ods.Extensions.Sk/EdFi.Ods.Extensions.Sk.nuspec -OutputDirectory NugetPackages -Version 1.0.$env:GITHUB_RUN_NUMBER -Properties configuration=release -Properties "authors=Ed-Fi Alliance" -Properties "owners=Ed-Fi Alliance" -Properties "copyright=Copyright ©Ed-Fi Alliance, LLC. 2020" -Properties id=EdFi.Ods.Extensions.Sk -Properties title=EdFi.Ods.Extensions.Sk -Properties description=EdFi.Ods.Extensions.Sk -NoPackageAnalysis -NoDefaultExcludes
 


### PR DESCRIPTION
Forcing nuget to use 5.3.1 to match with TeamCity and to avoid folder pathing issues when packing artifacts.  5.10 nuget cli seems to incorrectly pack the files without the root "Artifacts" folder.